### PR TITLE
Update README for S3 backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,15 @@ terraform state mv <src> <dest>   # Move resource in state
 terraform state rm <resource>     # Remove from state (not from cloud)
 ```
 
-**Remote Backend (S3 + DynamoDB for locking)**
+**Remote Backend (S3)**
 ```hcl
 terraform {
   backend "s3" {
     bucket         = "my-terraform-state"
     key            = "global/s3/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "terraform-lock"
     encrypt        = true
+    use_lockfile   = true
   }
 }
 ```


### PR DESCRIPTION
Removed DynamoDB locking configuration from S3 backend section.

https://developer.hashicorp.com/terraform/language/backend/s3

Terraform's S3 backend now supports native state locking using the use_lockfile = true
 

> **option, eliminating the need for a separate DynamoDB table for state locking**


<img width="727" height="649" alt="s3" src="https://github.com/user-attachments/assets/3b1fa3bb-3b5d-4bf4-9123-966daee537a4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Terraform Remote Backend configuration example to use lockfile-based state locking instead of DynamoDB table-based locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->